### PR TITLE
ember init (ember-cli@3.1.3)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,9 @@
-bower_components/
-tests/
-tmp/
-dist/
-
+/bower_components
+/config/ember-try.js
+/dist
+/tests
+/tmp
+**/.gitkeep
 .bowerrc
 .editorconfig
 .ember-cli
@@ -10,8 +11,6 @@ dist/
 .gitignore
 .watchmanconfig
 .travis.yml
-.npmignore
-**/.gitkeep
 bower.json
 ember-cli-build.js
 testem.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
@@ -28,7 +29,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
     - EMBER_TRY_SCENARIO=ember-lts-2.18
-    # - EMBER_TRY_SCENARIO=ember-release TODO: bug with ember-try
+    - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary
     - EMBER_TRY_SCENARIO=ember-default
@@ -37,7 +38,8 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-  - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
 before_install:
   - npm config set spin false
   - npm install -g npm@6

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp"]
+  "ignore_dirs": ["tmp", "dist"]
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// TODO: figure out why we need this
-// eslint-disable-next-line node/no-unpublished-require
 const getChannelURL = require('ember-source-channel-url');
 
 module.exports = function() {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,7 +8,7 @@ module.exports = function(defaults) {
   });
 
   /*
-    This build file specifes the options for the dummy test app of this
+    This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`
     This build file does *not* influence how the addon or the app using it
     behave. You most likely want to be modifying `./index.js` or app's build file

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-body-class',
-  included: function(app) {
-    this._super.included.apply(this, app);
-  }
+  name: 'ember-body-class'
 };

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "url": "https://github.com/stonecircle/ember-body-class"
   },
   "scripts": {
+    "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",
     "start": "ember serve",
     "test": "ember test",
-    "build": "ember build",
     "test:all": "ember try:each"
   },
   "dependencies": {
@@ -44,7 +44,6 @@
     "ember-cli-fastboot": "^1.1.4-beta.1",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
-    "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",
@@ -53,7 +52,6 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-fastboot-addon-tests": "^0.4.0",
-    "ember-get-config": "0.0.3",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -6,7 +6,7 @@ import config from './config/environment';
 const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -7,19 +7,19 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    {{content-for 'head'}}
+    {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 
-    {{content-for 'head-footer'}}
+    {{content-for "head-footer"}}
   </head>
   <body>
-    {{content-for 'body'}}
+    {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/dummy.js"></script>
 
-    {{content-for 'body-footer'}}
+    {{content-for "body-footer"}}
   </body>
 </html>


### PR DESCRIPTION
This PR is nothing more than running `ember init` with the currently specified ember-cli version.

It adopts the current shape of the blueprint in order to make future updates less-noisy.