### PR TITLE
Use the getOwner API to get the owner reference.

### DIFF
--- a/addon/mixins/body-class.js
+++ b/addon/mixins/body-class.js
@@ -1,11 +1,12 @@
 import Mixin from '@ember/object/mixin';
+import { getOwner } from '@ember/application';
 
 import { addClass, removeClass } from '../util/bodyClass';
 
 export default Mixin.create({
   actions: {
     loading(/* transition, route */) {
-      const document = this.owner.lookup('service:-document');
+      const document = getOwner(this).lookup('service:-document');
       const body = document.body;
 
       addClass(body, 'loading');
@@ -18,7 +19,7 @@ export default Mixin.create({
     },
 
     error: function(/* error, transition */) {
-      const document = this.owner.lookup('service:-document');
+      const document = getOwner(this).lookup('service:-document');
       const body = document.body;
 
       addClass(body, 'error');


### PR DESCRIPTION
I suspect that this PR will resolve [this canary failure](https://travis-ci.org/stonecircle/ember-body-class/jobs/403696867).

**Edit**: it did, but it revealed an additional error behind it. This is strictly an improvement, so I consider this safe to land. That additional error will be removed after refactoring the initializer in a follow-up PR.

Fixes: #15